### PR TITLE
Increase rcvbuf to 32k.

### DIFF
--- a/source/ui.cpp
+++ b/source/ui.cpp
@@ -577,7 +577,11 @@ int socketListen(u16 port) {
     if(fd < 0) {
         return -1;
     }
-
+    int rcvbuf = 32768;
+    if(setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf)) < 0) {
+        
+    }
+    
     struct sockaddr_in address;
     memset(&address, 0, sizeof(address));
     address.sin_family = AF_INET;


### PR DESCRIPTION
3ds's default rcvbuf is 4k, increase it, cia install speed is faster.
Rcvbuf of win and osx is 65535.