### PR TITLE
make screen_load_texture generic, and screen_load_texture_file for .png

### DIFF
--- a/source/screen.c
+++ b/source/screen.c
@@ -140,36 +140,36 @@ void screen_init() {
         tex->param = GPU_TEXTURE_MAG_FILTER(GPU_LINEAR) | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR) | GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE);
     }
 
-    screen_load_texture(TEXTURE_BOTTOM_SCREEN_BG, "bottom_screen_bg.png", true);
-    screen_load_texture(TEXTURE_BOTTOM_SCREEN_TOP_BAR, "bottom_screen_top_bar.png", true);
-    screen_load_texture(TEXTURE_BOTTOM_SCREEN_TOP_BAR_SHADOW, "bottom_screen_top_bar_shadow.png", true);
-    screen_load_texture(TEXTURE_BOTTOM_SCREEN_BOTTOM_BAR, "bottom_screen_bottom_bar.png", true);
-    screen_load_texture(TEXTURE_BOTTOM_SCREEN_BOTTOM_BAR_SHADOW, "bottom_screen_bottom_bar_shadow.png", true);
-    screen_load_texture(TEXTURE_TOP_SCREEN_BG, "top_screen_bg.png", true);
-    screen_load_texture(TEXTURE_TOP_SCREEN_TOP_BAR, "top_screen_top_bar.png", true);
-    screen_load_texture(TEXTURE_TOP_SCREEN_TOP_BAR_SHADOW, "top_screen_top_bar_shadow.png", true);
-    screen_load_texture(TEXTURE_TOP_SCREEN_BOTTOM_BAR, "top_screen_bottom_bar.png", true);
-    screen_load_texture(TEXTURE_TOP_SCREEN_BOTTOM_BAR_SHADOW, "top_screen_bottom_bar_shadow.png", true);
-    screen_load_texture(TEXTURE_LOGO, "logo.png", true);
-    screen_load_texture(TEXTURE_SELECTION_OVERLAY, "selection_overlay.png", true);
-    screen_load_texture(TEXTURE_BUTTON_SMALL, "button_small.png", true);
-    screen_load_texture(TEXTURE_BUTTON_LARGE, "button_large.png", true);
-    screen_load_texture(TEXTURE_PROGRESS_BAR_BG, "progress_bar_bg.png", true);
-    screen_load_texture(TEXTURE_PROGRESS_BAR_CONTENT, "progress_bar_content.png", true);
-    screen_load_texture(TEXTURE_SMDH_INFO_BOX, "smdh_info_box.png", true);
-    screen_load_texture(TEXTURE_SMDH_INFO_BOX_SHADOW, "smdh_info_box_shadow.png", true);
-    screen_load_texture(TEXTURE_BATTERY_CHARGING, "battery_charging.png", true);
-    screen_load_texture(TEXTURE_BATTERY_0, "battery0.png", true);
-    screen_load_texture(TEXTURE_BATTERY_1, "battery1.png", true);
-    screen_load_texture(TEXTURE_BATTERY_2, "battery2.png", true);
-    screen_load_texture(TEXTURE_BATTERY_3, "battery3.png", true);
-    screen_load_texture(TEXTURE_BATTERY_4, "battery4.png", true);
-    screen_load_texture(TEXTURE_BATTERY_5, "battery5.png", true);
-    screen_load_texture(TEXTURE_WIFI_DISCONNECTED, "wifi_disconnected.png", true);
-    screen_load_texture(TEXTURE_WIFI_0, "wifi0.png", true);
-    screen_load_texture(TEXTURE_WIFI_1, "wifi1.png", true);
-    screen_load_texture(TEXTURE_WIFI_2, "wifi2.png", true);
-    screen_load_texture(TEXTURE_WIFI_3, "wifi3.png", true);
+    screen_load_texture_file(TEXTURE_BOTTOM_SCREEN_BG, "bottom_screen_bg.png", true);
+    screen_load_texture_file(TEXTURE_BOTTOM_SCREEN_TOP_BAR, "bottom_screen_top_bar.png", true);
+    screen_load_texture_file(TEXTURE_BOTTOM_SCREEN_TOP_BAR_SHADOW, "bottom_screen_top_bar_shadow.png", true);
+    screen_load_texture_file(TEXTURE_BOTTOM_SCREEN_BOTTOM_BAR, "bottom_screen_bottom_bar.png", true);
+    screen_load_texture_file(TEXTURE_BOTTOM_SCREEN_BOTTOM_BAR_SHADOW, "bottom_screen_bottom_bar_shadow.png", true);
+    screen_load_texture_file(TEXTURE_TOP_SCREEN_BG, "top_screen_bg.png", true);
+    screen_load_texture_file(TEXTURE_TOP_SCREEN_TOP_BAR, "top_screen_top_bar.png", true);
+    screen_load_texture_file(TEXTURE_TOP_SCREEN_TOP_BAR_SHADOW, "top_screen_top_bar_shadow.png", true);
+    screen_load_texture_file(TEXTURE_TOP_SCREEN_BOTTOM_BAR, "top_screen_bottom_bar.png", true);
+    screen_load_texture_file(TEXTURE_TOP_SCREEN_BOTTOM_BAR_SHADOW, "top_screen_bottom_bar_shadow.png", true);
+    screen_load_texture_file(TEXTURE_LOGO, "logo.png", true);
+    screen_load_texture_file(TEXTURE_SELECTION_OVERLAY, "selection_overlay.png", true);
+    screen_load_texture_file(TEXTURE_BUTTON_SMALL, "button_small.png", true);
+    screen_load_texture_file(TEXTURE_BUTTON_LARGE, "button_large.png", true);
+    screen_load_texture_file(TEXTURE_PROGRESS_BAR_BG, "progress_bar_bg.png", true);
+    screen_load_texture_file(TEXTURE_PROGRESS_BAR_CONTENT, "progress_bar_content.png", true);
+    screen_load_texture_file(TEXTURE_SMDH_INFO_BOX, "smdh_info_box.png", true);
+    screen_load_texture_file(TEXTURE_SMDH_INFO_BOX_SHADOW, "smdh_info_box_shadow.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_CHARGING, "battery_charging.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_0, "battery0.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_1, "battery1.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_2, "battery2.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_3, "battery3.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_4, "battery4.png", true);
+    screen_load_texture_file(TEXTURE_BATTERY_5, "battery5.png", true);
+    screen_load_texture_file(TEXTURE_WIFI_DISCONNECTED, "wifi_disconnected.png", true);
+    screen_load_texture_file(TEXTURE_WIFI_0, "wifi0.png", true);
+    screen_load_texture_file(TEXTURE_WIFI_1, "wifi1.png", true);
+    screen_load_texture_file(TEXTURE_WIFI_2, "wifi2.png", true);
+    screen_load_texture_file(TEXTURE_WIFI_3, "wifi3.png", true);
 }
 
 void screen_exit() {
@@ -220,31 +220,7 @@ u32 next_pow_2(u32 i) {
     return i;
 }
 
-void screen_load_texture(u32 id, const char* path, bool linearFilter) {
-    if(id >= MAX_TEXTURES) {
-        util_panic("Attempted to load path \"%s\" to invalid texture ID \"%lu\".", path, id);
-        return;
-    }
-
-    u32 realPathSize = strlen(path) + 16;
-    char realPath[realPathSize];
-    snprintf(realPath, realPathSize, "sdmc:/fbitheme/%s", path);
-    FILE* fd = fopen(realPath, "rb");
-    if(fd != NULL) {
-        fclose(fd);
-    } else {
-        snprintf(realPath, realPathSize, "romfs:/%s", path);
-    }
-
-    unsigned char* image;
-    unsigned width;
-    unsigned height;
-    unsigned pngErr = lodepng_decode32_file(&image, &width, &height, realPath);
-    if(pngErr != 0) {
-        util_panic("Failed to load PNG file \"%s\": %u", realPath, pngErr);
-        return;
-    }
-
+void screen_load_texture(u32 id, unsigned char* image, u32 width, u32 height, bool linearFilter) {
     u32 pow2Width = next_pow_2(width);
     if(pow2Width < 64) {
         pow2Width = 64;
@@ -257,7 +233,7 @@ void screen_load_texture(u32 id, const char* path, bool linearFilter) {
 
     u8* gpuTex = linearAlloc(pow2Width * pow2Height * 4);
     if(gpuTex == NULL) {
-        util_panic("Failed to allocate temporary texture buffer for file \"%s\".", realPath);
+        util_panic("Failed to allocate temporary texture buffer for id \"%i\".", id);
         return;
     }
 
@@ -282,7 +258,7 @@ void screen_load_texture(u32 id, const char* path, bool linearFilter) {
     textures[id].pow2Height = pow2Height;
 
     if(!C3D_TexInit(&textures[id].tex, (int) pow2Width, (int) pow2Height, GPU_RGBA8)) {
-        util_panic("Failed to initialize texture for file \"%s\".", realPath);
+        util_panic("Failed to initialize texture for id \"%i\".", id);
         return;
     }
 
@@ -290,23 +266,70 @@ void screen_load_texture(u32 id, const char* path, bool linearFilter) {
 
     Result flushRes = GSPGPU_FlushDataCache(gpuTex, pow2Width * pow2Height * 4);
     if(R_FAILED(flushRes)) {
-        util_panic("Failed to flush texture buffer for file \"%s\": 0x%08lX", realPath, flushRes);
+        util_panic("Failed to flush texture buffer for id \"%i\": 0x%08lX", id, flushRes);
         return;
     }
 
     Result transferRes = GX_DisplayTransfer((u32*) gpuTex, GX_BUFFER_DIM(pow2Width, pow2Height), (u32*) textures[id].tex.data, GX_BUFFER_DIM(pow2Width, pow2Height), GX_TRANSFER_FLIP_VERT(1) | GX_TRANSFER_OUT_TILED(1) | GX_TRANSFER_RAW_COPY(0) | GX_TRANSFER_IN_FORMAT(GX_TRANSFER_FMT_RGBA8) | GX_TRANSFER_OUT_FORMAT(GX_TRANSFER_FMT_RGBA8) | GX_TRANSFER_SCALING(GX_TRANSFER_SCALE_NO));
     if(R_FAILED(transferRes)) {
-        util_panic("Failed to tile texture data for file \"%s\": 0x%08lX", realPath, transferRes);
+        util_panic("Failed to tile texture data for id \"%s\": 0x%08lX", id, transferRes);
         return;
     }
 
     gspWaitForPPF();
 
-    free(image);
     linearFree(gpuTex);
 }
 
-u32 screen_load_texture_auto(const char* path, bool linearFilter) {
+u32 screen_load_texture_auto(unsigned char* image, u32 width, u32 height, bool linearFilter) {
+    int id = -1;
+    for(int i = TEXTURE_AUTO_START; i < MAX_TEXTURES; i++) {
+        if(!textures[i].initialized) {
+            id = i;
+            break;
+        }
+    }
+
+    if(id == -1) {
+        util_panic("Attempted to load auto texture without free textures.");
+        return 0;
+    }
+
+    screen_load_texture((u32) id, image, width, height, linearFilter);
+    return (u32) id;
+}
+
+void screen_load_texture_file(u32 id, const char* path, bool linearFilter) {
+    if(id >= MAX_TEXTURES) {
+        util_panic("Attempted to load path \"%s\" to invalid texture ID \"%lu\".", path, id);
+        return;
+    }
+
+    u32 realPathSize = strlen(path) + 16;
+    char realPath[realPathSize];
+    snprintf(realPath, realPathSize, "sdmc:/fbitheme/%s", path);
+    FILE* fd = fopen(realPath, "rb");
+    if(fd != NULL) {
+        fclose(fd);
+    } else {
+        snprintf(realPath, realPathSize, "romfs:/%s", path);
+    }
+
+    unsigned char* image;
+    unsigned width;
+    unsigned height;
+    unsigned pngErr = lodepng_decode32_file(&image, &width, &height, realPath);
+    if(pngErr != 0) {
+        util_panic("Failed to load PNG file \"%s\": %u", realPath, pngErr);
+        return;
+    }
+
+    screen_load_texture(id, image, width, height, linearFilter);
+    free(image);
+    return;
+}
+
+u32 screen_load_texture_file_auto(const char* path, bool linearFilter) {
     int id = -1;
     for(int i = TEXTURE_AUTO_START; i < MAX_TEXTURES; i++) {
         if(!textures[i].initialized) {
@@ -320,7 +343,7 @@ u32 screen_load_texture_auto(const char* path, bool linearFilter) {
         return 0;
     }
 
-    screen_load_texture((u32) id, path, linearFilter);
+    screen_load_texture_file((u32) id, path, linearFilter);
     return (u32) id;
 }
 

--- a/source/screen.h
+++ b/source/screen.h
@@ -42,8 +42,10 @@
 
 void screen_init();
 void screen_exit();
-void screen_load_texture(u32 id, const char* path, bool linearFilter);
-u32 screen_load_texture_auto(const char* path, bool linearFilter);
+void screen_load_texture(u32 id, unsigned char* image, u32 width, u32 height, bool linearFilter);
+u32 screen_load_texture_auto(unsigned char* image, u32 width, u32 height, bool linearFilter);
+void screen_load_texture_file(u32 id, const char* path, bool linearFilter);
+u32 screen_load_texture_file_auto(const char* path, bool linearFilter);
 void screen_load_texture_tiled(u32 id, void* tiledData, u32 size, u32 width, u32 height, GPU_TEXCOLOR format, bool linearFilter);
 u32 screen_load_texture_tiled_auto(void* tiledData, u32 size, u32 width, u32 height, GPU_TEXCOLOR format, bool linearFilter);
 void screen_unload_texture(u32 id);


### PR DESCRIPTION
This is definitely not really to actually merge yet (it should probably also take the format in the args), but would you be willing to provide a load_texture function something like this, that can be used to load non-tiled graphics from a buffer? Is there a better way to do this already that I'm not seeing? Mostly I'm looking for a clean way to load the camera image as a texture in a manner that can be merged back into the main codebase at some point.

The end goal is that I'd like to be able to convert my http/mega.nz client into something that can be merged back into mainline FBI.