### PR TITLE
Quick key to Network Install

### DIFF
--- a/source/ui/mainmenu.c
+++ b/source/ui/mainmenu.c
@@ -47,6 +47,10 @@ static void mainmenu_update(ui_view* view, void* data, linked_list* items, list_
         ((void(*)()) selected->data)();
         return;
     }
+    
+    if(hidKeysDown() & KEY_Y) {
+        networkinstall_open();
+    }
 
     if(linked_list_size(items) == 0) {
         linked_list_add(items, &sd);
@@ -67,5 +71,5 @@ static void mainmenu_update(ui_view* view, void* data, linked_list* items, list_
 }
 
 void mainmenu_open() {
-    list_display("Main Menu", "A: Select, START: Exit", NULL, mainmenu_update, mainmenu_draw_top);
+    list_display("Main Menu", "A: Select, Y: Net Install, START: Exit", NULL, mainmenu_update, mainmenu_draw_top);
 }


### PR DESCRIPTION
Hi Steveice10,

This pull request contains a feature analogous to the homebrew launcher.  In HB launcher you can press Y in the main menu and it will automatically wait for a connection via 3dslink to send 3dsx homebrew to it. So I made a similar change to press Y to automatically bring up the network install menu.

Here is the use case.  I mainly test my apps via the cia version.  Network install is very far down the list so everytime I make a change I have to open FBI, scroll down to (or touch) the option and then run sockfile.jar (My makefile has a target that builds the cia and automatically does sends the cia). But to open FBI.  But yeah having this would speed up my workflow a bit since after this I wouldn't have to look at my 3ds to set up FBI for network install.

Thanks for FBI, network install, and sockfile.jar.  Made my life a lot easier.

Also your code is nice and clean! I found out where to make the appropriate edits in 2 guesses (first opened ui.c then saw mainmenu.c)