### PR TITLE
Drastically increase svchax reliability

### DIFF
--- a/source/svchax/svchax.c
+++ b/source/svchax/svchax.c
@@ -244,7 +244,8 @@ static void do_memchunkhax2(void)
          svcCloseHandle(mch2.threads[i].handle);
          mch2.threads[i].handle = 0;
       }
-
+   
+   svcSleepThread(40000000LL);
    svcCloseHandle(mch2.dummy_threads_lock);
 
    u32 fragmented_address = 0;


### PR DESCRIPTION
Tested on both Old and New 3DS w/ kver 2.50-9. 

Not entirely sure why this works, but it took my New 3DS from working 0% of the time to working seemingly 100% of the time. 

On two others' Old 3DSs, it seems to have marginally increased success rates.