### PR TITLE
add ETA in read/write tasks

### DIFF
--- a/source/core/util.c
+++ b/source/core/util.c
@@ -526,6 +526,18 @@ Result util_close_archive(FS_Archive archive) {
     return FSUSER_CloseArchive(archive);
 }
 
+const char* util_get_display_eta(u32 seconds) {
+    static char disp[9];
+
+    u8 hours     = seconds / 3600;
+    seconds     -= hours * 3600;
+    u8 minutes   = seconds / 60;
+    seconds     -= minutes* 60;
+
+    snprintf(disp, 9, "%02u:%02u:%02u", hours, minutes, (u8) seconds);
+    return disp;
+}
+
 double util_get_display_size(u64 size) {
     double s = size;
     if(s > 1024) {

--- a/source/core/util.h
+++ b/source/core/util.h
@@ -76,6 +76,7 @@ Result util_open_archive(FS_Archive* archive, FS_ArchiveID id, FS_Path path);
 Result util_ref_archive(FS_Archive archive);
 Result util_close_archive(FS_Archive archive);
 
+const char* util_get_display_eta(u32 seconds);
 double util_get_display_size(u64 size);
 const char* util_get_display_size_units(u64 size);
 

--- a/source/ui/section/action/erasetwlsave.c
+++ b/source/ui/section/action/erasetwlsave.c
@@ -122,7 +122,7 @@ static void action_erase_twl_save_update(ui_view* view, void* data, float* progr
     }
 
     *progress = eraseData->eraseInfo.currTotal != 0 ? (float) ((double) eraseData->eraseInfo.currProcessed / (double) eraseData->eraseInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s", util_get_display_size(eraseData->eraseInfo.currProcessed), util_get_display_size_units(eraseData->eraseInfo.currProcessed), util_get_display_size(eraseData->eraseInfo.currTotal), util_get_display_size_units(eraseData->eraseInfo.currTotal), util_get_display_size(eraseData->eraseInfo.copyBytesPerSecond), util_get_display_size_units(eraseData->eraseInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", util_get_display_size(eraseData->eraseInfo.currProcessed), util_get_display_size_units(eraseData->eraseInfo.currProcessed), util_get_display_size(eraseData->eraseInfo.currTotal), util_get_display_size_units(eraseData->eraseInfo.currTotal), util_get_display_size(eraseData->eraseInfo.copyBytesPerSecond), util_get_display_size_units(eraseData->eraseInfo.copyBytesPerSecond), util_get_display_eta(eraseData->eraseInfo.estimatedRemainingSeconds));
 }
 
 static void action_erase_twl_save_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/exporttwlsave.c
+++ b/source/ui/section/action/exporttwlsave.c
@@ -144,7 +144,7 @@ static void action_export_twl_save_update(ui_view* view, void* data, float* prog
     }
 
     *progress = exportData->exportInfo.currTotal != 0 ? (float) ((double) exportData->exportInfo.currProcessed / (double) exportData->exportInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s", util_get_display_size(exportData->exportInfo.currProcessed), util_get_display_size_units(exportData->exportInfo.currProcessed), util_get_display_size(exportData->exportInfo.currTotal), util_get_display_size_units(exportData->exportInfo.currTotal), util_get_display_size(exportData->exportInfo.copyBytesPerSecond), util_get_display_size_units(exportData->exportInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", util_get_display_size(exportData->exportInfo.currProcessed), util_get_display_size_units(exportData->exportInfo.currProcessed), util_get_display_size(exportData->exportInfo.currTotal), util_get_display_size_units(exportData->exportInfo.currTotal), util_get_display_size(exportData->exportInfo.copyBytesPerSecond), util_get_display_size_units(exportData->exportInfo.copyBytesPerSecond), util_get_display_eta(exportData->exportInfo.estimatedRemainingSeconds));
 }
 
 static void action_export_twl_save_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/importtwlsave.c
+++ b/source/ui/section/action/importtwlsave.c
@@ -130,7 +130,7 @@ static void action_import_twl_save_update(ui_view* view, void* data, float* prog
     }
 
     *progress = importData->importInfo.currTotal != 0 ? (float) ((double) importData->importInfo.currProcessed / (double) importData->importInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s", util_get_display_size(importData->importInfo.currProcessed), util_get_display_size_units(importData->importInfo.currProcessed), util_get_display_size(importData->importInfo.currTotal), util_get_display_size_units(importData->importInfo.currTotal), util_get_display_size(importData->importInfo.copyBytesPerSecond), util_get_display_size_units(importData->importInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", util_get_display_size(importData->importInfo.currProcessed), util_get_display_size_units(importData->importInfo.currProcessed), util_get_display_size(importData->importInfo.currTotal), util_get_display_size_units(importData->importInfo.currTotal), util_get_display_size(importData->importInfo.copyBytesPerSecond), util_get_display_size_units(importData->importInfo.copyBytesPerSecond), util_get_display_eta(importData->importInfo.estimatedRemainingSeconds));
 }
 
 static void action_import_twl_save_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/installcdn.c
+++ b/source/ui/section/action/installcdn.c
@@ -240,7 +240,7 @@ static void action_install_cdn_update(ui_view* view, void* data, float* progress
     }
 
     *progress = installData->installInfo.currTotal != 0 ? (float) ((double) installData->installInfo.currProcessed / (double) installData->installInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond), util_get_display_eta(installData->installInfo.estimatedRemainingSeconds));
 }
 
 static void action_install_cdn_n3ds_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/installcias.c
+++ b/source/ui/section/action/installcias.c
@@ -247,7 +247,7 @@ static void action_install_cias_update(ui_view* view, void* data, float* progres
     }
 
     *progress = installData->installInfo.currTotal != 0 ? (float) ((double) installData->installInfo.currProcessed / (double) installData->installInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond), util_get_display_eta(installData->installInfo.estimatedRemainingSeconds));
 }
 
 static void action_install_cias_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/installtickets.c
+++ b/source/ui/section/action/installtickets.c
@@ -210,7 +210,7 @@ static void action_install_tickets_update(ui_view* view, void* data, float* prog
     }
 
     *progress = installData->installInfo.currTotal != 0 ? (float) ((double) installData->installInfo.currProcessed / (double) installData->installInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond), util_get_display_eta(installData->installInfo.estimatedRemainingSeconds));
 }
 
 #define CDN_PROMPT_DEFAULT_VERSION 0

--- a/source/ui/section/action/installurl.c
+++ b/source/ui/section/action/installurl.c
@@ -287,7 +287,7 @@ static void action_install_url_install_update(ui_view* view, void* data, float* 
     }
 
     *progress = installData->installInfo.currTotal != 0 ? (float) ((double) installData->installInfo.currProcessed / (double) installData->installInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", installData->installInfo.processed, installData->installInfo.total, util_get_display_size(installData->installInfo.currProcessed), util_get_display_size_units(installData->installInfo.currProcessed), util_get_display_size(installData->installInfo.currTotal), util_get_display_size_units(installData->installInfo.currTotal), util_get_display_size(installData->installInfo.copyBytesPerSecond), util_get_display_size_units(installData->installInfo.copyBytesPerSecond), util_get_display_eta(installData->installInfo.estimatedRemainingSeconds));
 }
 
 static void action_install_url_confirm_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/action/pastecontents.c
+++ b/source/ui/section/action/pastecontents.c
@@ -279,7 +279,7 @@ static void action_paste_contents_update(ui_view* view, void* data, float* progr
     }
 
     *progress = pasteData->pasteInfo.currTotal != 0 ? (float) ((double) pasteData->pasteInfo.currProcessed / (double) pasteData->pasteInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s", pasteData->pasteInfo.processed, pasteData->pasteInfo.total, util_get_display_size(pasteData->pasteInfo.currProcessed), util_get_display_size_units(pasteData->pasteInfo.currProcessed), util_get_display_size(pasteData->pasteInfo.currTotal), util_get_display_size_units(pasteData->pasteInfo.currTotal), util_get_display_size(pasteData->pasteInfo.copyBytesPerSecond), util_get_display_size_units(pasteData->pasteInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%lu / %lu\n%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", pasteData->pasteInfo.processed, pasteData->pasteInfo.total, util_get_display_size(pasteData->pasteInfo.currProcessed), util_get_display_size_units(pasteData->pasteInfo.currProcessed), util_get_display_size(pasteData->pasteInfo.currTotal), util_get_display_size_units(pasteData->pasteInfo.currTotal), util_get_display_size(pasteData->pasteInfo.copyBytesPerSecond), util_get_display_size_units(pasteData->pasteInfo.copyBytesPerSecond), util_get_display_eta(pasteData->pasteInfo.estimatedRemainingSeconds));
 }
 
 static void action_paste_contents_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/dumpnand.c
+++ b/source/ui/section/dumpnand.c
@@ -122,7 +122,7 @@ static void dumpnand_update(ui_view* view, void* data, float* progress, char* te
     }
 
     *progress = dumpData->currTotal != 0 ? (float) ((double) dumpData->currProcessed / (double) dumpData->currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s", util_get_display_size(dumpData->currProcessed), util_get_display_size_units(dumpData->currProcessed), util_get_display_size(dumpData->currTotal), util_get_display_size_units(dumpData->currTotal), util_get_display_size(dumpData->copyBytesPerSecond), util_get_display_size_units(dumpData->copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", util_get_display_size(dumpData->currProcessed), util_get_display_size_units(dumpData->currProcessed), util_get_display_size(dumpData->currTotal), util_get_display_size_units(dumpData->currTotal), util_get_display_size(dumpData->copyBytesPerSecond), util_get_display_size_units(dumpData->copyBytesPerSecond), util_get_display_eta(dumpData->estimatedRemainingSeconds));
 }
 
 static void dumpnand_onresponse(ui_view* view, void* data, u32 response) {

--- a/source/ui/section/task/dataop.c
+++ b/source/ui/section/task/dataop.c
@@ -68,6 +68,7 @@ static Result task_data_op_copy(data_op_data* data, u32 index) {
                     if(buffer != NULL) {
                         u32 dstHandle = 0;
 
+                        u64 ioStartTime = 0;
                         u64 lastBytesPerSecondUpdate = osGetTime();
                         u32 bytesSinceUpdate = 0;
 
@@ -102,6 +103,15 @@ static Result task_data_op_copy(data_op_data* data, u32 index) {
                             u64 elapsed = time - lastBytesPerSecondUpdate;
                             if(elapsed >= 1000) {
                                 data->copyBytesPerSecond = (u32) (bytesSinceUpdate / (elapsed / 1000.0f));
+
+                                if (ioStartTime != 0) {
+                                        data->estimatedRemainingSeconds = (u32) ((data->currTotal - data->currProcessed) / (data->currProcessed / ((time - ioStartTime) / 1000.0f)));
+                                } else {
+                                        data->estimatedRemainingSeconds = 0;
+                                }
+                                if (ioStartTime == 0 && data->currProcessed > 0) {
+                                        ioStartTime = time;
+                                }
 
                                 bytesSinceUpdate = 0;
                                 lastBytesPerSecondUpdate = time;

--- a/source/ui/section/task/task.h
+++ b/source/ui/section/task/task.h
@@ -107,6 +107,7 @@ typedef struct data_op_data_s {
     bool copyEmpty;
 
     u32 copyBytesPerSecond;
+    u32 estimatedRemainingSeconds;
 
     u32 processed;
     u32 total;

--- a/source/ui/section/update.c
+++ b/source/ui/section/update.c
@@ -151,7 +151,7 @@ static void update_install_update(ui_view* view, void* data, float* progress, ch
     }
 
     *progress = updateData->installInfo.currTotal != 0 ? (float) ((double) updateData->installInfo.currProcessed / (double) updateData->installInfo.currTotal) : 0;
-    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s", util_get_display_size(updateData->installInfo.currProcessed), util_get_display_size_units(updateData->installInfo.currProcessed), util_get_display_size(updateData->installInfo.currTotal), util_get_display_size_units(updateData->installInfo.currTotal), util_get_display_size(updateData->installInfo.copyBytesPerSecond), util_get_display_size_units(updateData->installInfo.copyBytesPerSecond));
+    snprintf(text, PROGRESS_TEXT_MAX, "%.2f %s / %.2f %s\n%.2f %s/s, ETA %s", util_get_display_size(updateData->installInfo.currProcessed), util_get_display_size_units(updateData->installInfo.currProcessed), util_get_display_size(updateData->installInfo.currTotal), util_get_display_size_units(updateData->installInfo.currTotal), util_get_display_size(updateData->installInfo.copyBytesPerSecond), util_get_display_size_units(updateData->installInfo.copyBytesPerSecond), util_get_display_eta(updateData->installInfo.estimatedRemainingSeconds));
 }
 
 static void update_check_update(ui_view* view, void* data, float* progress, char* text) {


### PR DESCRIPTION
This branch adds an ETA in all read/write operations that use `task_data_op_copy`. This is really neat for long operations such as NAND dump or big CIA installs.

I previously tried to compute it only over the last second, but as sometimes i/o speed is unstable, the computed ETA could be very erratic. Then I tried to compute it since the copy operation started, but as for some operations (such as CIA installs), the first copied bytes can take a few seconds, this was impacting the ETA calculation.

I ended up computing it since the first written byte, which is not too bad (tested on NAND dump and CIA install).

Any comments are welcome. I tried to respect the coding style as mush as I could :)