### PR TITLE
Add setup.py

### DIFF
--- a/servefiles/setup.py
+++ b/servefiles/setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# coding: utf-8 -*-
+
+from setuptools import setup
+
+setup(
+	name="servefiles",
+	version="2.4.12",
+	scripts=["servefiles.py", "sendurls.py"],
+	author="Steveice10",
+	author_email="Steveice10@gmail.com",
+	description="Simple Python script for serving local files to FBI's remote installer.",
+	license="MIT",
+	url="https://github.com/Steveice10/FBI/tree/master/servefiles"
+)


### PR DESCRIPTION
I sent servefiles to [homebrew](brew.sh), a package manager for macOS (Homebrew/homebrew-core/pull/18718). The homebrew maintainers told me to ask if you could add a Makefile/setup.py script, so I created a setup.py script and created this PR.